### PR TITLE
Add support for bedrock-angular for v2 and v3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # bedrock-angular-footer ChangeLog
 
+### Changed
+- Add support for bedrock-angular to work with footer v2 and v3.
+
 ## 3.0.0 - 2017-03-01
 
 ### Added

--- a/footer-component.html
+++ b/footer-component.html
@@ -1,5 +1,5 @@
-<footer ng-if="$ctrl.route.vars.footer" class="container footer">
-  <hr>
+<hr ng-if="$ctrl.route.vars.footer.show">
+<footer ng-if="$ctrl.route.vars.footer.show" class="container footer">
   <div class="row">
     <div class="col-md-12">
       <ul class="list-unstyled">

--- a/main.js
+++ b/main.js
@@ -25,8 +25,13 @@ module.config(function($routeProvider) {
       route.vars = {};
     }
     if(!('footer' in route.vars)) {
-      route.vars.footer = true;
+      route.vars.footer = {};
     }
+    if(!('show' in route.vars.footer)) {
+      route.vars.footer.show = true;
+    }
+    // backwards compatibility outer hr display
+    route.vars.footer._hideOuterHr = true;
     return when.apply($routeProvider, arguments);
   };
 });


### PR DESCRIPTION
Add support for bedrock-angular to work with footer v2 and v3. <hr> was
moved inside footer, so use private var only set in v3 to hide the outer
hr.

bedrock-angular will be released first for this and dep here will be updated.